### PR TITLE
Minor tweaks to get relationship working

### DIFF
--- a/EarthVerse.API/Persistence/Contexts/AppDbContext.cs
+++ b/EarthVerse.API/Persistence/Contexts/AppDbContext.cs
@@ -25,7 +25,7 @@ namespace EarthVerse.API.Persistence.Contexts
             builder.Entity<Item>().HasKey(i => i.ItemID);
             builder.Entity<Item>().Property(i => i.ItemID).IsRequired().ValueGeneratedOnAdd();
             builder.Entity<Item>().Property(i => i.ItemName).IsRequired().HasMaxLength(30);
-            builder.Entity<Item>().HasOne(i => i.Equipment).WithOne(e => e.Item).HasForeignKey<Item>(p => p.ItemID);
+            // builder.Entity<Item>().HasOne(i => i.Equipment).WithOne(e => e.Item).HasForeignKey<Item>(p => p.ItemID);
 
             builder.Entity<Item>().HasData
             (
@@ -40,8 +40,8 @@ namespace EarthVerse.API.Persistence.Contexts
 
             builder.Entity<Equipment>().HasData
             (
-                new Equipment {  EquipmentID = 15, equipmentType = EquipmentType.Overall},
-                new Equipment {  EquipmentID = 16, equipmentType = EquipmentType.Pants}
+                new Equipment {  EquipmentID = 15, ItemID = 101, equipmentType = EquipmentType.Overall},
+                new Equipment {  EquipmentID = 16, ItemID = 102, equipmentType = EquipmentType.Pants}
             );
         }
     }

--- a/EarthVerse.API/Persistence/Repositories/ItemRepository.cs
+++ b/EarthVerse.API/Persistence/Repositories/ItemRepository.cs
@@ -17,7 +17,7 @@ namespace EarthVerse.API.Persistence.Repositories
 
         public async Task<IEnumerable<Item>> ListAsync()
         {
-            return await _context.Item.ToListAsync();
+            return await _context.Item.Include(i => i.Equipment).ToListAsync();
         }
     }
 }


### PR DESCRIPTION
If I make these changes then it loads the item properly.  I'm not sure why I have to remove the `HasOne`.  It seems like it should work either way.  Maybe it wants the other side to be the owner (e.g. do the `HasOne` on `builder.Entity<Equipment>` or maybe it just really doesn't like the `HasForeignKey`)

You don't actually have to merge this, just using it to demo what I did.